### PR TITLE
Pull npy to csv and run tsne

### DIFF
--- a/masif_files/extract_descriptors_to_csv.py
+++ b/masif_files/extract_descriptors_to_csv.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pandas as pd
+from pathlib import Path
+import argparse
+
+def load_mapping(mapping_path):
+    """Load mapping from 4-digit symlinks to real file names."""
+    mapping = {}
+    with open(mapping_path) as f:
+        for line in f:
+            symlink, real = line.strip().split(" -> ")
+            mapping[symlink.replace(".pdb", "")] = real.replace(".pdb", "")
+    return mapping
+
+def collect_descriptors(output_dir, mapping, use_flipped=False):
+    """
+    Collect descriptor vectors from MaSIF output folders.
+    """
+    data = []
+    labels = []
+    desc_file = "p1_desc_flipped.npy" if use_flipped else "p1_desc_straight.npy"
+
+    for pdb_dir in sorted(Path(output_dir).glob("*")):
+        structure_id = pdb_dir.name
+        descriptor_path = pdb_dir / "descriptors" / "sc05" / "all_feat" / f"{structure_id}_A" / desc_file
+
+        if descriptor_path.exists():
+            try:
+                vector = np.load(descriptor_path).flatten()
+                real_name = mapping.get(structure_id, structure_id)
+                data.append(vector)
+                labels.append(real_name)
+            except Exception as e:
+                print(f"[WARN] Could not load {descriptor_path}: {e}")
+        else:
+            print(f"[WARN] Missing: {descriptor_path}")
+
+    df = pd.DataFrame(data)
+    df.insert(0, "structure", labels)
+    return df
+
+def main():
+    parser = argparse.ArgumentParser(description="Extract MaSIF descriptors into a CSV file.")
+    parser.add_argument("--output_dir", type=str, required=True, help="Directory with masif_output/")
+    parser.add_argument("--log_dir", type=str, required=True, help="Directory with pdb_mapping.txt")
+    parser.add_argument("--csv_path", type=str, default="masif_descriptors.csv", help="Output CSV file path")
+    parser.add_argument("--metadata_csv", type=str, help="Optional metadata CSV to merge on 'structure'")
+    parser.add_argument("--use_flipped", action="store_true", help="Use p1_desc_flipped.npy instead of straight")
+    args = parser.parse_args()
+
+    output_dir = Path(args.output_dir)
+    log_dir = Path(args.log_dir)
+    mapping_path = log_dir / "pdb_mapping.txt"
+
+    if not mapping_path.exists():
+        print(f"[ERROR] Mapping file not found: {mapping_path}")
+        return
+
+    mapping = load_mapping(mapping_path)
+    df = collect_descriptors(output_dir, mapping, use_flipped=args.use_flipped)
+
+    if args.metadata_csv:
+        metadata = pd.read_csv(args.metadata_csv)
+        df = df.merge(metadata, on="structure", how="left")
+
+    df.to_csv(args.csv_path, index=False)
+    print(f"[INFO] Saved descriptor matrix: {args.csv_path}")
+
+if __name__ == "__main__":
+    main()
+

--- a/masif_files/run_tsne.py
+++ b/masif_files/run_tsne.py
@@ -1,0 +1,46 @@
+import pandas as pd
+from sklearn.manifold import TSNE
+import matplotlib.pyplot as plt
+import seaborn as sns
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser(description="Run t-SNE on MaSIF descriptors.")
+    parser.add_argument('-i','--input_csv', type=str, required=True, help='CSV file with descriptors')
+    parser.add_argument('-o', '--output_prefix', type=str, default='tsne_output', help='Prefix for output files')
+    parser.add_argument('-p', '--perplexity', type=float, default=20.0, help='Perplexity for t-SNE (must be < num samples)')
+    parser.add_argument('-n', '--n_iter', type=int, default=1000, help='Number of iterations for t-SNE')
+    args = parser.parse_args()
+
+    # Load input descriptor data
+    df = pd.read_csv(args.input_csv)
+    if 'structure' not in df.columns:
+        raise ValueError("Input CSV must have a 'structure' column.")
+
+    # Split features and fill missing values
+    features = df.drop(columns=['structure']).fillna(0)
+    structures = df['structure']
+
+    if args.perplexity >= len(features):
+        raise ValueError(f"Perplexity ({args.perplexity}) must be < number of samples ({len(features)}).")
+
+    # Run t-SNE
+    tsne = TSNE(n_components=2, perplexity=args.perplexity, n_iter=args.n_iter, random_state=42)
+    coords = tsne.fit_transform(features)
+
+    # Save results
+    result_df = pd.DataFrame({'x': coords[:, 0], 'y': coords[:, 1], 'structure': structures})
+    result_df.to_csv(f"{args.output_prefix}.csv", index=False)
+
+    # Plot
+    plt.figure(figsize=(8, 6))
+    sns.scatterplot(data=result_df, x='x', y='y', s=40, alpha=0.8)
+    plt.title("t-SNE of MaSIF Descriptors")
+    plt.axis('off')
+    plt.tight_layout()
+    plt.savefig(f"{args.output_prefix}.png", dpi=300)
+
+    print(f"[INFO] t-SNE complete. Saved to {args.output_prefix}.csv and .png")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Currently set to fill missing values/NaNs with 0s.

`extract_descriptors_to_csv.py` can take in a supplementary metadata file that should be of the format:

structure,sequence,ligand_name,ligand_family

- The `structure` column must match the original structure names in `pdb_mapping.txt`.
- Additional columns (e.g., sequence, ligand_name, ligand_family) are optional and customizable.
- Metadata will be merged into the final descriptors CSV to enable downstream visualization (e.g., coloring t-SNE plots by ligand family).

The t-sne script will take in that csv and output a png and an additional csv with point coordinates.